### PR TITLE
precompile guards for strlcpy if implemented

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -138,6 +138,7 @@ xasprintf(const char *format, ...)
     return s;
 }
 
+#ifndef HAVE_STRLCPY
 void
 strlcpy(char *dst, const char *src, size_t size)
 {
@@ -148,6 +149,7 @@ strlcpy(char *dst, const char *src, size_t size)
         dst[n_copy] = '\0';
     }
 }
+#endif
 
 void
 ofp_fatal(int err_no, const char *format, ...)

--- a/lib/util.h
+++ b/lib/util.h
@@ -42,6 +42,10 @@
 #include <string.h>
 #include "compiler.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifndef va_copy
 #ifdef __va_copy
 #define va_copy __va_copy


### PR DESCRIPTION
Rationale:

* The header file had the guards around the function declaration, but guard variable was not brought in, so build was noping out on double-definition. Added the include for `config.h` which makes it available.
* The C file had no guard around the function definition like it did around declaration, so included an analogous one here.

My reasoning is that this must have been oversight because compilers at the time were not expected to ever have that function defined? The assymetry very much suggests this.

I found only one other fork that does something about this:
https://github.com/mininet/openflow/compare/master...JsphByd:openflow:master

But their solution is more complex. Not certain how to judge the merits.